### PR TITLE
[ci skip] adding user @rvalieris

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @dhirschfeld
+* @rvalieris

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,4 +41,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - rvalieris
     - dhirschfeld


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @rvalieris as instructed in #3.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #3